### PR TITLE
Explore using markdown for in-class slides

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,42 @@
+# Slide Decks
+
+For use during the classroom portion of JumpStart Live
+
+## How does it work?
+
+To keep things simple,
+
+* Each slide deck is a single markdown file that can be easily edited and
+  versioned.
+* Through `index.html`, [Remark](http://remarkjs.com) converts the markdown
+  document into an HTML slideshow.
+* Lastly, Github Pages hosts this folder as a website, allowing anyone with an
+  internet connection to access the slides.
+
+## You said I can look at the slides?
+Absolutely! Go to Ada-Developers-Academy.github.io/jump-start-live to see.
+
+## I made changes, how can I view the slides locally?
+That's awesome, thank you so much for contributing!
+
+So long as you have a locally running webserver that is able to serve the
+contents of this directory, you can view them. Python's `http.server` module
+works fine for this purpose. In a terminal, navigate to this directory
+```console
+$ pwd
+/home/brooks/code/jump-start-live/docs
+```
+
+start the server
+```console
+$ python3 -m http.server --bind 127.0.0.1
+Serving HTTP on 127.0.0.1 port 8000 (http://127.0.0.1:8000/) ...
+```
+
+Then point your browser to http://localhost:8000
+
+## Slide syntax
+
+If you want to work on the slides, take a look at [remark's github wiki page on
+Markdown](https://github.com/gnab/remark/wiki/Markdown), it will tell you
+almost everything you need to know to get started editing or creating slides.

--- a/docs/index.html
+++ b/docs/index.html
@@ -51,7 +51,7 @@ You can also use these links to navigate to a specific day
       const slideDeck = new URL(window.location.href).searchParams.get("slides")
       console.log(slideDeck)
       if (slideDeck !== null) {
-        options.sourceUrl = `/slides/${slideDeck}.md`
+        options.sourceUrl = `slides/${slideDeck}.md`
       }
 
       var slideshow = remark.create(options);

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>My Awesome Presentation</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <style type="text/css">
+      @import url(https://fonts.googleapis.com/css?family=Yanone+Kaffeesatz);
+      @import url(https://fonts.googleapis.com/css?family=Droid+Serif:400,700,400italic);
+      @import url(https://fonts.googleapis.com/css?family=Ubuntu+Mono:400,700,400italic);
+
+      body { font-family: 'Droid Serif'; }
+      h1, h2, h3 {
+        font-family: 'Yanone Kaffeesatz';
+        font-weight: normal;
+      }
+      .remark-code, .remark-inline-code { font-family: 'Ubuntu Mono'; }
+    </style>
+  </head>
+  <body>
+    <textarea id="source">
+# Jumpstart Live in class slides
+
+This is the landing page for the slides used in the Jumpstart Live class. To
+load a slide deck, add its name as the `slides` url parameter to this page.
+
+For example, to load the slide deck for the first day, simply add
+
+```js
+?slides=day1
+```
+
+to the url. One caveat, though, is that the parameter **must** appear before
+any hashtags (**`#`**) present in the url.
+
+You can also use these links to navigate to a specific day
+
+1. [day 1](?slides=day1)
+2. [day 2](?slides=day2)
+3. [day 3](?slides=day3)
+4. [day 4](?slides=day4)
+5. [day 5](?slides=day5)
+6. [day 6](?slides=day6)
+    </textarea>
+    <script src="https://remarkjs.com/downloads/remark-latest.min.js" type="text/javascript">
+    </script>
+    <script type="text/javascript">
+      const options = {
+      }
+
+      // Determine which presentation to load
+      const slideDeck = new URL(window.location.href).searchParams.get("slides")
+      console.log(slideDeck)
+      if (slideDeck !== null) {
+        options.sourceUrl = `/slides/${slideDeck}.md`
+      }
+
+      var slideshow = remark.create(options);
+    </script>
+  </body>
+</html>

--- a/docs/slides/day1.md
+++ b/docs/slides/day1.md
@@ -1,0 +1,50 @@
+class: middle, center
+
+# Jumpstart Live
+
+In classroom conversation for day 1
+
+---
+
+# Hello
+
+Introduce yourself!
+* Name
+* Pronouns
+* What you were doing before Ada **OR** something interesting about yourself
+
+---
+
+# Peer code review: Candy Machine
+
+Pointers for code review:
+* Ruby style guides: snake_case, spaces, comments, indentation
+
+* Are all minimal requirements followed and working?
+
+* Are any additional, optional requirements coded and working?
+
+* User experience
+    * Are the prompts useful, educational, and sufficient for the user of the
+      program who is unaware of the requirements?
+
+    * What is the user enters information in an incorrect format? (case
+      insensitive input, detailed error messages, prompt for re-entry)
+
+P.S: for easier code reviews, save files with `.rb` extensions in your gists.
+This allows for better formatting. Saving multiple `.rb` files helps scope the
+feedback and test code as you make changes.
+
+---
+
+# Workflow
+
+Goal
+* Be comfortable writing and executing programs on your machine
+
+Tools needed
+* VS Code, or another text editor
+* terminal, or another terminal emulator such as iTerm2
+* ruby
+    * What version do you have? Run **`ruby --version`** in a terminal
+* irb


### PR DESCRIPTION
This is an initial attempt at giving us the ability to write our in-class slides in markdown format, as opposed to keeping them in Google Drive.

Ideally, this
* gives us greater (version) control over the content of the slides
* makes it easier for students to discover/refer to the slides on their own.

Let me know what you think. My original idea was to use a static site generator like pelican, jekyll, or hugo, to create this content, but I figured this half-way solution
* is less complex than the alternative
* is easier to understand than the alternative
* still works fine for our needs

@beccaelenzil I added you as a reviewer because @CheezItMan did the same thing on the last pull request, so I figured it wouldn't hurt. If you have no opinion or aren't interested in this, feel free to ignore.

![jsl-day1-remark](https://user-images.githubusercontent.com/2654835/70370370-6acbb300-187b-11ea-90a3-b84085d71ef8.png)
<sup>Preview of the first slide</sup>

---

If this gets approved and merged, the next step after this would be to enable `/docs` gh-pages in in the project settings
![gh-pages-settings](https://user-images.githubusercontent.com/2654835/70370371-6acbb300-187b-11ea-8476-bd6734682675.png)