### PR TITLE
Apply minimal css styling (in slides) for table readability

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -14,6 +14,14 @@
         font-weight: normal;
       }
       .remark-code, .remark-inline-code { font-family: 'Ubuntu Mono'; }
+
+      table {
+        border-collapse: collapse;
+      }
+
+      table, th, td {
+        border: 1px solid black;
+      }
     </style>
   </head>
   <body>


### PR DESCRIPTION
This pull request adds very minimal css styling for `<table>` elements, for each presentation

---

Example of day 1, slide 13 without this border:
![no-table-styling](https://user-images.githubusercontent.com/2654835/71708958-4fd05e00-2da9-11ea-8e8f-a0aa267c225c.png)

---

But with this css change:
![table-styling](https://user-images.githubusercontent.com/2654835/71708959-55c63f00-2da9-11ea-8de8-6e4a5c573699.png)
