### PR TITLE
Use github colorscheme for slides

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -63,7 +63,8 @@ You can also use these links to navigate to a specific day
     </script>
     <script type="text/javascript">
       const options = {
-        highlightLines: true
+        highlightLines: true,
+        highlightStyle: "github"
       }
 
       // Determine which presentation to load


### PR DESCRIPTION
Instead of the default.

# Default colorscheme
Before this change, the slides used the default colorscheme. For example, day2 slide 32 looks like this
![day2-slide32-default](https://user-images.githubusercontent.com/2654835/71760133-6809b100-2e6d-11ea-9e61-a72939faae16.png)

# Github colorscheme
But with the github colorscheme applied, looks like this
![day2-slide-32](https://user-images.githubusercontent.com/2654835/71760117-3d1f5d00-2e6d-11ea-86c2-6b6aadf97505.png)



Requested by @CheezItMan at https://github.com/Ada-Developers-Academy/jump-start-live/pull/31#discussion_r362927875.

What do you think? To be honest, I don't think this is a complete parity of the Github colorscheme. I'm betting it's totally possible to create your own colorscheme that more closely mimics Github's true colors, if that's the way we want to go, but I'd prioritize finishing the rest of the slides before doing that.