### PR TITLE
Rename Jumpstart --> JumpStart in slides

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>My Awesome Presentation</title>
+    <title>JumpStart Live Slides</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <style type="text/css">
       @import url(https://fonts.googleapis.com/css?family=Yanone+Kaffeesatz);
@@ -36,9 +36,9 @@
   </head>
   <body>
     <textarea id="source">
-# Jumpstart Live in class slides
+# JumpStart Live in class slides
 
-This is the landing page for the slides used in the Jumpstart Live class. To
+This is the landing page for the slides used in the JumpStart Live class. To
 load a slide deck, add its name as the `slides` url parameter to this page.
 
 For example, to load the slide deck for the first day, simply add
@@ -68,8 +68,9 @@ You can also use these links to navigate to a specific day
 
       // Determine which presentation to load
       const slideDeck = new URL(window.location.href).searchParams.get("slides")
-      console.log(slideDeck)
       if (slideDeck !== null) {
+        console.log(`loading ${slideDeck} slide deck`)
+        document.title = slideDeck + ' | ' + document.title
         options.sourceUrl = `slides/${slideDeck}.md`
       }
 

--- a/docs/slides/day1.md
+++ b/docs/slides/day1.md
@@ -14,7 +14,7 @@ class: middle, center
   }
 </style>
 
-# Jumpstart Live
+# JumpStart Live
 
 In classroom conversation for day 1
 


### PR DESCRIPTION
Everything else in this repository uses `JumpStart` capitalization, so I wanted to make the few spots where it wasn't, consistent.

---

And also set the page title for in-class slides appropriately.

Instead of all the slides having `My Awesome Presentation` for the window title, the slides homepage has `JumpStart Live Slides`, and each slide deck has the name in the title.

Eg, for day1, it is `day1 | JumpStart Live Slides`
![day1-title](https://user-images.githubusercontent.com/2654835/71787214-fdba5300-2fc9-11ea-8909-786d9b8280e7.png)
